### PR TITLE
Revert back to IsAnInteractiveSession

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,3 +42,20 @@ jobs:
       run: |
         go get github.com/kisielk/errcheck
         errcheck -blank -asserts ./...
+  
+  test:
+    name: test
+    strategy:
+      matrix:
+        go-version: [1.16.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Test
+      run: go test -cover -timeout 2m

--- a/svc_windows.go
+++ b/svc_windows.go
@@ -12,8 +12,12 @@ import (
 	wsvc "golang.org/x/sys/windows/svc"
 )
 
-// Create variables for svc and signal functions so we can mock them in tests
-var svcIsWindowsService = wsvc.IsWindowsService
+// Create function and variable for svc and signal functions so we can mock them in tests
+func svcIsWindowsService() bool {
+	// Use deprecated function because IsWindowsService requires Admin rights
+	return !wsvc.IsAnInteractiveSession()
+}
+
 var svcRun = wsvc.Run
 
 type windowsService struct {

--- a/svc_windows.go
+++ b/svc_windows.go
@@ -12,12 +12,15 @@ import (
 	wsvc "golang.org/x/sys/windows/svc"
 )
 
-// Create function and variable for svc and signal functions so we can mock them in tests
-func svcIsWindowsService() bool {
+// Create a function and assign it to svcIsWindowsService so tests are not broken
+func svcIsWindowsServiceFunc() (bool, error) {
 	// Use deprecated function because IsWindowsService requires Admin rights
-	return !wsvc.IsAnInteractiveSession()
+	b, err := wsvc.IsAnInteractiveSession()
+	return !b, err
 }
 
+// Create function and variable for svc and signal functions so we can mock them in tests
+var svcIsWindowsService = svcIsWindowsServiceFunc
 var svcRun = wsvc.Run
 
 type windowsService struct {

--- a/svc_windows_test.go
+++ b/svc_windows_test.go
@@ -48,7 +48,6 @@ func setupWinServiceTest(wsf *mockWinServiceFuncs) {
 	}
 
 	signalNotify = wsfWrapper.signalNotify
-	svcIsWindowsService = wsfWrapper.svcIsWindowsService
 	svcRun = wsfWrapper.svcRun
 }
 

--- a/svc_windows_test.go
+++ b/svc_windows_test.go
@@ -48,6 +48,7 @@ func setupWinServiceTest(wsf *mockWinServiceFuncs) {
 	}
 
 	signalNotify = wsfWrapper.signalNotify
+	svcIsWindowsService = wsfWrapper.svcIsWindowsService
 	svcRun = wsfWrapper.svcRun
 }
 


### PR DESCRIPTION
Revert back to using IsAnInteractiveSession command because the newer IsWindowService requires Administrator rights. It is bad practice to run a service with administrator rights if it doesn't need them for anything. 

See more information in https://github.com/golang/go/issues/45966